### PR TITLE
Add api-version to StrikeTab

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ main: ga.strikepractice.striketab.StrikeTab
 version: 0.3.12
 name: StrikeTab
 author: Toppe
+api-version: 1.13
 website: https://github.com/toppev/strike-tab
 description: Tablist addon for StrikePractice
 depend: [PlaceholderAPI, ProtocolLib]


### PR DESCRIPTION
Makes sure StrikeTab is not the reason being your server enabling legacy mode